### PR TITLE
Reverting changes

### DIFF
--- a/extension-src/plugin.lua
+++ b/extension-src/plugin.lua
@@ -44,41 +44,21 @@ function init(plugin)
         },
         utils = dofile(app.fs.joinPath(app.fs.userConfigPath, "extensions", "Balamod_Extension_Tools", "helpers.lua")),
     };
-    print("Registering Balamod Extension Tools menu group")
-    plugin:newMenuGroup{
-        id="balamod_extension_tools",
-        title="Balamod",
-        group="main_menu"
-    }
-    print("Registering Balamod Extension Tools commands")
-    print("Registering Balamod Extension Tools Templates command")
-    plugin:newCommand {
-        id="balamod_extension_tools_templates",
-        title="Templates",
-        group="balamod_extension_tools",
-        onclick=function()
-            loadFile(data, "Dialogs", "Templates.lua")
-        end
-    }
-    print("Registering Balamod Extension Tools Blindify command")
-    plugin:newCommand {
-        id="balamod_extension_tools_blindify",
-        title="Blindify",
-        group="balamod_extension_tools",
-        onclick=function()
-            loadFile(data, "Blindify.lua")
-        end
-    }
-    print("Registering Balamod Extension Tools 1X to 2X scaler command")
-    plugin:newCommand {
-        id="balamod_extension_tools_scaler",
-        title="1X to 2X scaler",
-        group="balamod_extension_tools",
-        onclick=function()
-            loadFile(data, "1Xto2X.lua")
-        end
-    }
-    print("Balamod extension tools installed.")
+    
+    local function AddCommand(id, title, group, file, loc)
+        plugin:newCommand {
+            id=id,
+            title=title,
+            group=group,
+            onclick=function()
+                loadfile(app.fs.joinPath(app.fs.userConfigPath, "extensions", "Balamod_Extension_Tools", loc, file))(data);
+            end
+        }
+    end
+
+    AddCommand("Balamod_Extension_Templates","Templates","file_new","TemplateWindow.lua", "Dialogs");
+    AddCommand("Balamod_Extension_Tools_Blindify", "Blindify", "file_new", "Blindify.lua", "")
+    AddCommand("Balamod_Extension_Tools_Scaler", "1X to 2X scaler", "file_new", "1Xto2X.lua", "")
 end
 
 function exit(plugin)


### PR DESCRIPTION
The new updates to the plugin commands are good changes, and would improve the organization of the plugin, but unfortunately Aseprite's menu API doesn't like menu groups. I haven't been able to get them to successfully work, and this version, too, is broken. The original version of plugin.lua functions flawlessly, and it's only 3 commands so shouldn't bloat up the menus too much.